### PR TITLE
Update tr.utran

### DIFF
--- a/Lang-src/tr.utran
+++ b/Lang-src/tr.utran
@@ -126,7 +126,7 @@
     </text>
     <text id="12">
      <orig>12th</orig>
-     <transl>12’inci</transl>
+     <transl>12’nci</transl>
     </text>
     <text id="13">
      <orig>13th</orig>


### PR DESCRIPTION
misspelling: 12’inci
correct: 12’nci